### PR TITLE
Return first vehicle log

### DIFF
--- a/car_workshop/car_workshop/api.py
+++ b/car_workshop/car_workshop/api.py
@@ -25,7 +25,7 @@ def get_latest_vehicle_log(customer_vehicle):
         "Vehicle Change Log",
         filters={"customer_vehicle": customer_vehicle},
         fields=[
-            "fieldname", 
+            "fieldname",
             "old_value", 
             "new_value", 
             "change_date", 
@@ -36,5 +36,4 @@ def get_latest_vehicle_log(customer_vehicle):
         order_by="creation desc",
         limit=1
     )
-    
-    # Return data
+    return logs[0] if logs else None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,36 @@
+import sys
+import types
+from pathlib import Path
+
+# Create a stub frappe module
+def identity_decorator(*args, **kwargs):
+    def wrapper(fn):
+        return fn
+    return wrapper
+
+
+frappe_stub = types.SimpleNamespace(
+    db=types.SimpleNamespace(exists=lambda doctype, name: True),
+    get_all=lambda *args, **kwargs: [],
+    whitelist=identity_decorator,
+    _=lambda msg: msg,
+    throw=lambda msg: (_ for _ in ()).throw(Exception(msg)),
+)
+
+sys.modules['frappe'] = frappe_stub
+
+# Ensure the package root is on the path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from car_workshop.car_workshop import api
+
+
+def test_get_latest_vehicle_log_returns_first_log():
+    frappe_stub.get_all = lambda *args, **kwargs: [{"fieldname": "mileage"}]
+    assert api.get_latest_vehicle_log("CV-001") == {"fieldname": "mileage"}
+
+
+def test_get_latest_vehicle_log_returns_none_when_no_logs():
+    frappe_stub.get_all = lambda *args, **kwargs: []
+    assert api.get_latest_vehicle_log("CV-001") is None
+


### PR DESCRIPTION
## Summary
- return the first vehicle change log when available
- add tests for vehicle log retrieval

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895fcd87628832cae508e7a389dec6a