### PR TITLE
Enforce read permissions on vehicle change logs

### DIFF
--- a/car_workshop/car_workshop/api.py
+++ b/car_workshop/car_workshop/api.py
@@ -5,21 +5,38 @@ from frappe import _
 @frappe.whitelist()
 def get_latest_vehicle_log(customer_vehicle):
     """
-    Mengambil log perubahan terakhir untuk kendaraan tertentu
-    
+    Mengambil log perubahan terakhir untuk kendaraan tertentu.
+
+    Pengguna harus memiliki hak baca pada doctype "Vehicle Change Log" atau pada
+    dokumen "Customer Vehicle" yang bersangkutan. Jika tidak, fungsi akan
+    mengeluarkan `frappe.PermissionError`.
+
     Args:
         customer_vehicle (str): Nama/ID kendaraan pelanggan
-        
+
     Returns:
         dict: Data log perubahan terakhir atau None jika tidak ditemukan
     """
     if not customer_vehicle:
         return None
-        
+
     # Cek apakah customer_vehicle tersebut ada
     if not frappe.db.exists("Customer Vehicle", customer_vehicle):
         frappe.throw(_("Kendaraan dengan ID {} tidak ditemukan").format(customer_vehicle))
-    
+
+    customer_vehicle_doc = frappe.get_doc("Customer Vehicle", customer_vehicle)
+
+    # Pastikan pengguna memiliki hak baca
+    has_log_perm = frappe.has_permission("Vehicle Change Log", ptype="read")
+    has_vehicle_perm = frappe.has_permission(
+        "Customer Vehicle", doc=customer_vehicle_doc, ptype="read"
+    )
+    if not has_log_perm and not has_vehicle_perm:
+        frappe.throw(
+            _("Anda tidak memiliki izin untuk melihat log perubahan kendaraan ini."),
+            frappe.PermissionError,
+        )
+
     # Ambil log perubahan terakhir
     logs = frappe.get_all(
         "Vehicle Change Log",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 import sys
 import types
 from pathlib import Path
+import pytest
 
 # Create a stub frappe module
 def identity_decorator(*args, **kwargs):
@@ -14,7 +15,10 @@ frappe_stub = types.SimpleNamespace(
     get_all=lambda *args, **kwargs: [],
     whitelist=identity_decorator,
     _=lambda msg: msg,
-    throw=lambda msg: (_ for _ in ()).throw(Exception(msg)),
+    throw=lambda *args, **kwargs: (_ for _ in ()).throw(Exception(args[0] if args else "")),
+    get_doc=lambda doctype, name: types.SimpleNamespace(),
+    has_permission=lambda *args, **kwargs: True,
+    PermissionError=Exception,
 )
 
 sys.modules['frappe'] = frappe_stub
@@ -26,11 +30,19 @@ from car_workshop.car_workshop import api
 
 
 def test_get_latest_vehicle_log_returns_first_log():
+    frappe_stub.has_permission = lambda *args, **kwargs: True
     frappe_stub.get_all = lambda *args, **kwargs: [{"fieldname": "mileage"}]
     assert api.get_latest_vehicle_log("CV-001") == {"fieldname": "mileage"}
 
 
 def test_get_latest_vehicle_log_returns_none_when_no_logs():
+    frappe_stub.has_permission = lambda *args, **kwargs: True
     frappe_stub.get_all = lambda *args, **kwargs: []
     assert api.get_latest_vehicle_log("CV-001") is None
+
+
+def test_get_latest_vehicle_log_permission_denied():
+    frappe_stub.has_permission = lambda *args, **kwargs: False
+    with pytest.raises(Exception):
+        api.get_latest_vehicle_log("CV-001")
 


### PR DESCRIPTION
## Summary
- Validate user permissions for Vehicle Change Log or associated Customer Vehicle before returning change data
- Document required access rights in `get_latest_vehicle_log`
- Extend tests with permission checks and denied access coverage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895fec799ec832c8797b65bf1b133b2