### PR TITLE
Validate work order details before submission

### DIFF
--- a/car_workshop/car_workshop/doctype/work_order/work_order.py
+++ b/car_workshop/car_workshop/doctype/work_order/work_order.py
@@ -95,9 +95,12 @@ class WorkOrder(Document):
     def before_submit(self):
         # Validate all important fields are filled before submitting
         self.validate_important_fields()
-        
-        # Validate part details before submission
+
+        # Validate details before submission
         self.validate_part_details_before_submit()
+        self.validate_job_types_before_submit()
+        self.validate_service_packages_before_submit()
+        self.validate_expenses_before_submit()
     
     def validate_important_fields(self):
         """Validate mandatory fields before submission"""


### PR DESCRIPTION
## Summary
- ensure `WorkOrder.before_submit` validates job types, service packages, and expenses

## Testing
- `pytest -q`
- Manual check to confirm submission fails when job type price, service package total price, or expense amount is missing

------
https://chatgpt.com/codex/tasks/task_e_6895ffacfb1c832cbafff14f173d1b55