### PR TITLE
Import get_mapped_doc for material issue mapping

### DIFF
--- a/car_workshop/car_workshop/doctype/work_order/work_order.py
+++ b/car_workshop/car_workshop/doctype/work_order/work_order.py
@@ -3,6 +3,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.model.naming import make_autoname
 from frappe.utils import flt
+from frappe.model.mapper import get_mapped_doc
 
 
 class WorkOrder(Document):
@@ -241,5 +242,5 @@ def make_material_issue(source_name, target_doc=None):
             "postprocess": update_item
         }
     }, target_doc, set_missing_values)
-    
+
     return target_doc


### PR DESCRIPTION
## Summary
- add missing frappe mapper import in work order doctype
- ensure make_material_issue runs without NameError

## Testing
- `python - <<'PY' ...` (call make_material_issue)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68960d4c8b14832ca11d7f351fb08535