### PR TITLE
Fix SQL parameterization in purchase invoice query

### DIFF
--- a/car_workshop/car_workshop/doctype/workshop_purchase_invoice/workshop_purchase_invoice.py
+++ b/car_workshop/car_workshop/doctype/workshop_purchase_invoice/workshop_purchase_invoice.py
@@ -330,13 +330,13 @@ def get_unpaid_purchase_order_items(purchase_order):
     for item in po_items:
         # Check if this item is referenced in any submitted invoice
         paid_invoices = frappe.db.sql("""
-            SELECT parent 
-            FROM `tabWorkshop Purchase Invoice Item` 
-            WHERE item_reference = %s 
+            SELECT parent
+            FROM `tabWorkshop Purchase Invoice Item`
+            WHERE item_reference = %s
             AND docstatus = 1
-        """, item.name, as_dict=1)
+        """, (item.name,), as_dict=1)
         
         if not paid_invoices:
             unpaid_items.append(item)
-    
+
     return unpaid_items


### PR DESCRIPTION
## Summary
- ensure tuple-based parameters in unpaid purchase order lookup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896203dda08832cbdf3fa085b7e7c98