### PR TITLE
Validate positive quantity and rate for work order parts

### DIFF
--- a/car_workshop/car_workshop/doctype/work_order_part/work_order_part.py
+++ b/car_workshop/car_workshop/doctype/work_order_part/work_order_part.py
@@ -46,9 +46,9 @@ class WorkOrderPart(Document):
                 self.purchase_order = None
     
     def calculate_amount(self):
-        """Calculate amount based on quantity and rate"""
-        if self.quantity and self.rate:
-            self.amount = flt(self.quantity) * flt(self.rate)
-        else:
-            # Ensure amount is 0 if either quantity or rate is missing
-            self.amount = 0
+        """Validate quantity and rate then calculate amount"""
+        if flt(self.quantity) <= 0:
+            frappe.throw(_("Quantity must be greater than zero"))
+        if flt(self.rate) <= 0:
+            frappe.throw(_("Rate must be greater than zero"))
+        self.amount = flt(self.quantity) * flt(self.rate)

--- a/tests/test_work_order_part.py
+++ b/tests/test_work_order_part.py
@@ -1,0 +1,52 @@
+import sys
+import types
+from pathlib import Path
+import pytest
+
+# Stub Frappe modules and Document class
+class Document:
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+frappe_utils_stub = types.SimpleNamespace(flt=lambda x: float(x or 0))
+
+frappe_stub = types.SimpleNamespace(
+    _=lambda msg: msg,
+    throw=lambda *args, **kwargs: (_ for _ in ()).throw(Exception(args[0] if args else "")),
+    utils=frappe_utils_stub,
+)
+
+frappe_stub.model = types.SimpleNamespace(
+    document=types.SimpleNamespace(Document=Document)
+)
+
+# Register stubs in sys.modules
+sys.modules['frappe'] = frappe_stub
+sys.modules['frappe.model'] = frappe_stub.model
+sys.modules['frappe.model.document'] = frappe_stub.model.document
+sys.modules['frappe.utils'] = frappe_utils_stub
+
+# Ensure the package root is on the path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from car_workshop.car_workshop.doctype.work_order_part.work_order_part import WorkOrderPart
+
+
+def test_calculate_amount_succeeds_with_positive_values():
+    part = WorkOrderPart(quantity=2, rate=5)
+    part.calculate_amount()
+    assert part.amount == 10
+
+
+def test_calculate_amount_raises_for_non_positive_quantity():
+    part = WorkOrderPart(quantity=0, rate=5)
+    with pytest.raises(Exception):
+        part.calculate_amount()
+
+
+def test_calculate_amount_raises_for_non_positive_rate():
+    part = WorkOrderPart(quantity=1, rate=0)
+    with pytest.raises(Exception):
+        part.calculate_amount()
+


### PR DESCRIPTION
## Summary
- validate quantity and rate are greater than zero before computing amount on Work Order Parts
- add tests for Work Order Part amount validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68962cafb3a8832c85631fcd2cdfe5e0