### PR TITLE
Ensure customer vehicle plate numbers are unique

### DIFF
--- a/car_workshop/car_workshop/doctype/customer_vehicle/customer_vehicle.py
+++ b/car_workshop/car_workshop/doctype/customer_vehicle/customer_vehicle.py
@@ -10,6 +10,17 @@ class CustomerVehicle(Document):
         Run validation checks before document save
         """
         validate_plate_number(self)
+        # Ensure license plate numbers are unique across Customer Vehicle records
+        if self.plate_number:
+            existing = frappe.db.get_value(
+                "Customer Vehicle", {"plate_number": self.plate_number}, "name"
+            )
+            if existing and existing != self.name:
+                frappe.throw(
+                    _(
+                        "License plate number {0} is already assigned to another vehicle ({1})"
+                    ).format(self.plate_number, existing)
+                )
         update_fuel_type(self)
     
     def on_update(self):

--- a/car_workshop/patches.txt
+++ b/car_workshop/patches.txt
@@ -1,1 +1,2 @@
 # Patches file - disimpan di car_workshop/patches.txt
+car_workshop.patches.add_unique_index_on_customer_vehicle_plate

--- a/car_workshop/patches/__init__.py
+++ b/car_workshop/patches/__init__.py
@@ -1,0 +1,1 @@
+# Patches package for car_workshop app

--- a/car_workshop/patches/add_unique_index_on_customer_vehicle_plate.py
+++ b/car_workshop/patches/add_unique_index_on_customer_vehicle_plate.py
@@ -1,0 +1,5 @@
+import frappe
+
+def execute():
+    """Ensure plate_number on Customer Vehicle has a unique index"""
+    frappe.db.add_index("Customer Vehicle", "plate_number", unique=True)

--- a/tests/test_customer_vehicle.py
+++ b/tests/test_customer_vehicle.py
@@ -1,0 +1,41 @@
+import sys
+import types
+from pathlib import Path
+import pytest
+
+# Stub Document
+class Document:
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+# Frappe stub
+frappe_stub = types.SimpleNamespace(
+    db=types.SimpleNamespace(get_value=lambda *args, **kwargs: None),
+    throw=lambda *args, **kwargs: (_ for _ in ()).throw(Exception(args[0] if args else "")),
+    _=lambda msg: msg,
+)
+frappe_stub.model = types.SimpleNamespace(document=types.SimpleNamespace(Document=Document))
+
+# Register stubs
+sys.modules['frappe'] = frappe_stub
+sys.modules['frappe.model'] = frappe_stub.model
+sys.modules['frappe.model.document'] = frappe_stub.model.document
+
+# Ensure package root on path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from car_workshop.car_workshop.doctype.customer_vehicle.customer_vehicle import CustomerVehicle
+
+
+def test_validate_rejects_duplicate_plate():
+    frappe_stub.db.get_value = lambda doctype, filters, field: "OTHER-VEHICLE"
+    vehicle = CustomerVehicle(name="CURRENT", plate_number="B 1234 CD", model=None)
+    with pytest.raises(Exception):
+        vehicle.validate()
+
+
+def test_validate_allows_unique_plate():
+    frappe_stub.db.get_value = lambda doctype, filters, field: None
+    vehicle = CustomerVehicle(name="CV-001", plate_number="B 1234 CD", model=None)
+    vehicle.validate()


### PR DESCRIPTION
## Summary
- validate duplicate license plate numbers when saving Customer Vehicle records
- add database patch to enforce unique index on `plate_number`
- cover validation with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68962dcdcae8832c83b1fe9c2a0f7b88