### PR TITLE
refactor: rely on frappe transaction management

### DIFF
--- a/car_workshop/car_workshop/doctype/part_stock_adjustment/part_stock_adjustment.py
+++ b/car_workshop/car_workshop/doctype/part_stock_adjustment/part_stock_adjustment.py
@@ -432,8 +432,6 @@ class PartStockAdjustment(Document):
             stock_entry.flags.ignore_permissions = True
             stock_entry.insert()
             stock_entry.submit()
-            
-            frappe.db.commit()
             return stock_entry
         except Exception as e:
             frappe.db.rollback()

--- a/car_workshop/car_workshop/doctype/return_material/return_material.py
+++ b/car_workshop/car_workshop/doctype/return_material/return_material.py
@@ -257,7 +257,6 @@ class ReturnMaterial(Document):
             # Save the work order with updated consumed quantities
             work_order.flags.ignore_validate_update_after_submit = True
             work_order.save()
-            frappe.db.commit()
     
     def cancel_stock_entry_if_exists(self):
         """Cancel the corresponding Stock Entry if it exists"""
@@ -308,7 +307,6 @@ class ReturnMaterial(Document):
             # Save the work order with restored consumed quantities
             work_order.flags.ignore_validate_update_after_submit = True
             work_order.save()
-            frappe.db.commit()
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Summary
- remove manual DB commits when updating work order quantities
- rely on automatic transactions for part stock adjustment stock entry

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689630b6fbb0832c8f8b163d2da001a7