### PR TITLE
Use blank purchase order reference

### DIFF
--- a/car_workshop/car_workshop/doctype/work_order_part/work_order_part.py
+++ b/car_workshop/car_workshop/doctype/work_order_part/work_order_part.py
@@ -43,7 +43,7 @@ class WorkOrderPart(Document):
         else:
             # Clear purchase order if source is not "Beli Baru"
             if self.purchase_order:
-                self.purchase_order = None
+                self.purchase_order = ""
     
     def calculate_amount(self):
         """Validate quantity and rate then calculate amount"""

--- a/car_workshop/patches.txt
+++ b/car_workshop/patches.txt
@@ -1,1 +1,2 @@
 # Patches file - disimpan di car_workshop/patches.txt
+car_workshop.patches.replace_null_purchase_order

--- a/car_workshop/patches/replace_null_purchase_order.py
+++ b/car_workshop/patches/replace_null_purchase_order.py
@@ -1,0 +1,13 @@
+import frappe
+
+
+def execute():
+    """Set empty string for missing purchase order values"""
+    frappe.db.sql(
+        """
+        update `tabWork Order Part`
+        set purchase_order = ''
+        where purchase_order is null
+        """
+    )
+

--- a/tests/test_work_order_part.py
+++ b/tests/test_work_order_part.py
@@ -50,3 +50,15 @@ def test_calculate_amount_raises_for_non_positive_rate():
     with pytest.raises(Exception):
         part.calculate_amount()
 
+
+def test_validate_source_and_po_clears_purchase_order():
+    part = WorkOrderPart(source="Dari Stok", purchase_order="PO-001")
+    part.validate_source_and_po()
+    assert part.purchase_order == ""
+
+
+def test_validate_source_and_po_requires_purchase_order_when_buying():
+    part = WorkOrderPart(source="Beli Baru", purchase_order="")
+    with pytest.raises(Exception):
+        part.validate_source_and_po()
+


### PR DESCRIPTION
## Summary
- Clear purchase_order with a blank string instead of `None`
- Migrate existing Work Order Part rows with NULL purchase_order to empty strings
- Test source and purchase order validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689632f689d4832c94d5c357bf8fbd84