### PR TITLE
Use part detail for work order parts

### DIFF
--- a/tests/test_workshop_material_issue.py
+++ b/tests/test_workshop_material_issue.py
@@ -1,0 +1,15 @@
+from test_item_code_resolution import setup_frappe_stub, import_doctype
+
+
+def test_get_work_order_parts_uses_part_detail():
+    frappe = setup_frappe_stub()
+    module = import_doctype(
+        "car_workshop.car_workshop.doctype.workshop_material_issue.workshop_material_issue"
+    )
+    module.frappe = frappe
+    parts = module.get_work_order_parts("WO-001")
+    assert parts[0]["part"] == "PART-001"
+    assert parts[0]["required_qty"] == 2
+    assert parts[0]["consumed_qty"] == 1
+    assert parts[0]["qty"] == 1
+


### PR DESCRIPTION
## Summary
- update Workshop Material Issue to pull parts from Work Order's `part_detail` table instead of `required_items`
- compute remaining and consumed quantities using `quantity`/`consumed_qty`
- extend tests and stubs for the new part detail logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896340066e4832ca8a4833d172e30cf