### PR TITLE
refactor: use part detail for work order parts

### DIFF
--- a/car_workshop/car_workshop/doctype/workshop_material_issue/workshop_material_issue.py
+++ b/car_workshop/car_workshop/doctype/workshop_material_issue/workshop_material_issue.py
@@ -361,17 +361,17 @@ class WorkshopMaterialIssue(Document):
             updated_items = []
             
             for item in self.items:
-                # Find the matching required item in the Work Order
-                for wo_item in work_order.required_items:
+                # Find the matching part in the Work Order
+                for wo_item in work_order.part_detail:
                     if wo_item.item_code == item.item_code:
-                        previous_qty = flt(wo_item.consumed_qty)
-                        
+                        previous_qty = flt(getattr(wo_item, "consumed_qty", 0))
+
                         if cancel:
                             # Ensure we don't go below zero
-                            wo_item.consumed_qty = max(0, flt(wo_item.consumed_qty) - flt(item.qty))
+                            wo_item.consumed_qty = max(0, previous_qty - flt(item.qty))
                         else:
-                            wo_item.consumed_qty = flt(wo_item.consumed_qty) + flt(item.qty)
-                        
+                            wo_item.consumed_qty = previous_qty + flt(item.qty)
+
                         # Track if any change was made
                         if previous_qty != wo_item.consumed_qty:
                             changes_made = True
@@ -380,7 +380,7 @@ class WorkshopMaterialIssue(Document):
                                 "previous_qty": previous_qty,
                                 "new_qty": wo_item.consumed_qty
                             })
-                            
+
                         break
             
             # Only update if changes were made
@@ -464,53 +464,50 @@ class WorkshopMaterialIssue(Document):
 
 @frappe.whitelist()
 def get_work_order_parts(work_order):
-    """Get required parts from a Work Order"""
+    """Get required parts from a Work Order using the part detail table"""
     if not work_order:
         return []
-    
+
     wo = frappe.get_doc("Work Order", work_order)
-    
-    # Get required items from the Work Order
+
     required_items = []
-    for item in wo.required_items:
-        # Find the corresponding Part for this item
-        parts = frappe.get_all("Part", 
-            filters={"item": item.item_code},
-            fields=["name", "description"])
-        
-        if not parts:
+    for item in getattr(wo, "part_detail", []) or []:
+        if not getattr(item, "item_code", None):
             continue
-        
-        part = parts[0]
-        
+
         # Get stock information
-        bin_data = frappe.db.get_value("Bin", 
-            {"item_code": item.item_code, "warehouse": wo.source_warehouse}, 
-            ["actual_qty", "reserved_qty", "valuation_rate"], 
-            as_dict=1) or {"actual_qty": 0, "reserved_qty": 0, "valuation_rate": 0}
-        
-        # Calculate remaining quantity to be issued
-        consumed_qty = flt(item.consumed_qty)
-        required_qty = flt(item.required_qty)
+        bin_data = frappe.db.get_value(
+            "Bin",
+            {"item_code": item.item_code, "warehouse": wo.source_warehouse},
+            ["actual_qty", "reserved_qty", "valuation_rate"],
+            as_dict=1,
+        ) or {"actual_qty": 0, "reserved_qty": 0, "valuation_rate": 0}
+
+        consumed_qty = flt(getattr(item, "consumed_qty", 0))
+        required_qty = flt(getattr(item, "quantity", 0))
         remaining_qty = required_qty - consumed_qty
-        
-        # Calculate available quantity considering reserved qty
-        available_qty = flt(bin_data.actual_qty) - flt(bin_data.reserved_qty)
-        
-        # Only include items that haven't been fully consumed
+
+        actual_qty = flt(bin_data.get("actual_qty"))
+        reserved_qty = flt(bin_data.get("reserved_qty"))
+        rate = flt(bin_data.get("valuation_rate"))
+        available_qty = actual_qty - reserved_qty
+
         if remaining_qty > 0:
-            required_items.append({
-                "part": part.name,
-                "item_code": item.item_code,
-                "description": part.description,
-                "qty": min(remaining_qty, available_qty),  # Don't issue more than available
-                "uom": frappe.db.get_value("Item", item.item_code, "stock_uom"),
-                "rate": bin_data.valuation_rate,
-                "amount": bin_data.valuation_rate * min(remaining_qty, available_qty),
-                "required_qty": required_qty,
-                "consumed_qty": consumed_qty,
-                "available_qty": available_qty,
-                "work_order_item": item.name
-            })
-    
+            issue_qty = min(remaining_qty, available_qty)
+            required_items.append(
+                {
+                    "part": getattr(item, "part", None),
+                    "item_code": item.item_code,
+                    "description": getattr(item, "part_name", ""),
+                    "qty": issue_qty,
+                    "uom": frappe.db.get_value("Item", item.item_code, "stock_uom"),
+                    "rate": rate,
+                    "amount": rate * issue_qty,
+                    "required_qty": required_qty,
+                    "consumed_qty": consumed_qty,
+                    "available_qty": available_qty,
+                    "work_order_item": item.name,
+                }
+            )
+
     return required_items

--- a/tests/test_workshop_material_issue_parts.py
+++ b/tests/test_workshop_material_issue_parts.py
@@ -1,0 +1,86 @@
+import sys
+import types
+import importlib
+from pathlib import Path
+
+# Ensure package root on path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def setup_frappe_stub():
+    frappe = types.ModuleType("frappe")
+    frappe._ = lambda m: m
+
+    class DB:
+        def get_value(self, doctype, name=None, fieldname=None, as_dict=False, **kwargs):
+            if doctype == "Bin":
+                return {"actual_qty": 5, "reserved_qty": 1, "valuation_rate": 10}
+            if doctype == "Item" and fieldname == "stock_uom":
+                return "Nos"
+            return None
+
+    frappe.db = DB()
+
+    def get_doc(doctype, name):
+        if doctype == "Work Order":
+            part = types.SimpleNamespace(
+                part="PART-001",
+                part_name="Test Part",
+                item_code="ITEM-001",
+                consumed_qty=1,
+                quantity=3,
+                name="WO_PART_1",
+            )
+            return types.SimpleNamespace(part_detail=[part], source_warehouse="WH")
+        return types.SimpleNamespace()
+
+    frappe.get_doc = get_doc
+    frappe.get_all = lambda *args, **kwargs: []
+    utils = types.ModuleType("frappe.utils")
+    utils.flt = float
+    utils.cint = int
+    utils.getdate = lambda v: v
+    utils.nowdate = lambda: "2024-01-01"
+    utils.nowtime = lambda: "00:00:00"
+    frappe.utils = utils
+    frappe.whitelist = lambda *args, **kwargs: (lambda f: f)
+
+    sys.modules["frappe"] = frappe
+    sys.modules["frappe.utils"] = utils
+    model = types.ModuleType("frappe.model")
+    document = types.ModuleType("frappe.model.document")
+    class Document:
+        pass
+    document.Document = Document
+    model.document = document
+    sys.modules["frappe.model"] = model
+    sys.modules["frappe.model.document"] = document
+    erpnext = types.ModuleType("erpnext")
+    stock = types.ModuleType("erpnext.stock")
+    doctype = types.ModuleType("erpnext.stock.doctype")
+    stock_entry = types.ModuleType("erpnext.stock.doctype.stock_entry")
+    stock_entry_module = types.ModuleType("erpnext.stock.doctype.stock_entry.stock_entry")
+    stock_entry_module.get_uom_details = lambda *args, **kwargs: None
+    sys.modules["erpnext"] = erpnext
+    sys.modules["erpnext.stock"] = stock
+    sys.modules["erpnext.stock.doctype"] = doctype
+    sys.modules["erpnext.stock.doctype.stock_entry"] = stock_entry
+    sys.modules["erpnext.stock.doctype.stock_entry.stock_entry"] = stock_entry_module
+
+    return frappe
+
+
+def import_doctype(module_name):
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
+
+
+def test_get_work_order_parts_uses_part_detail():
+    setup_frappe_stub()
+    module = import_doctype(
+        "car_workshop.car_workshop.doctype.workshop_material_issue.workshop_material_issue"
+    )
+    parts = module.get_work_order_parts("WO-001")
+    assert parts[0]["required_qty"] == 3
+    assert parts[0]["consumed_qty"] == 1
+    assert parts[0]["qty"] == 2


### PR DESCRIPTION
## Summary
- use `part_detail` entries instead of `required_items` when updating work order consumption
- derive required and consumed quantities from work order part records in `get_work_order_parts`
- add regression test covering part retrieval from work order

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896360a5844832c891236a07c828099