### PR TITLE
Use Work Order warehouse field for material issue

### DIFF
--- a/car_workshop/car_workshop/doctype/work_order/work_order.py
+++ b/car_workshop/car_workshop/doctype/work_order/work_order.py
@@ -202,7 +202,7 @@ def make_material_issue(source_name, target_doc=None):
         # Set valuation rate and amount based on warehouse stock
         bin_data = frappe.db.get_value(
             "Bin",
-            {"item_code": source_obj.item_code, "warehouse": source_parent.source_warehouse},
+            {"item_code": source_obj.item_code, "warehouse": source_parent.set_warehouse},
             ["valuation_rate"],
             as_dict=1,
         ) or {"valuation_rate": 0}
@@ -219,7 +219,7 @@ def make_material_issue(source_name, target_doc=None):
             "doctype": "Workshop Material Issue",
             "field_map": {
                 "name": "work_order",
-                "source_warehouse": "set_warehouse"
+                "set_warehouse": "set_warehouse"
             },
             "validation": {
                 "docstatus": ["=", 1]  # Only allow if Work Order is submitted

--- a/car_workshop/car_workshop/doctype/workshop_material_issue/workshop_material_issue.js
+++ b/car_workshop/car_workshop/doctype/workshop_material_issue/workshop_material_issue.js
@@ -53,7 +53,7 @@ frappe.ui.form.on('Workshop Material Issue', {
                     if (r.message) {
                         // Set warehouse from Work Order if empty
                         if (!frm.doc.set_warehouse) {
-                            frm.set_value('set_warehouse', r.message.source_warehouse);
+                            frm.set_value('set_warehouse', r.message.set_warehouse);
                         }
                         
                         // Ask user if they want to fetch required parts
@@ -439,7 +439,7 @@ frappe.provide('car_workshop.car_workshop.doctype.work_order.work_order');
 car_workshop.car_workshop.doctype.work_order.work_order.make_material_issue = function(frm) {
     frappe.route_options = {
         "work_order": frm.doc.name,
-        "set_warehouse": frm.doc.source_warehouse
+        "set_warehouse": frm.doc.set_warehouse
     };
     frappe.new_doc("Workshop Material Issue");
 };

--- a/car_workshop/car_workshop/doctype/workshop_material_issue/workshop_material_issue.py
+++ b/car_workshop/car_workshop/doctype/workshop_material_issue/workshop_material_issue.py
@@ -486,7 +486,7 @@ def get_work_order_parts(work_order):
         # Get stock information
         bin_data = frappe.db.get_value(
             "Bin",
-            {"item_code": item.item_code, "warehouse": wo.source_warehouse},
+            {"item_code": item.item_code, "warehouse": wo.set_warehouse},
             ["actual_qty", "reserved_qty", "valuation_rate"],
             as_dict=1,
         ) or {"actual_qty": 0, "reserved_qty": 0, "valuation_rate": 0}

--- a/tests/test_workshop_material_issue_parts.py
+++ b/tests/test_workshop_material_issue_parts.py
@@ -31,7 +31,7 @@ def setup_frappe_stub():
                 quantity=3,
                 name="WO_PART_1",
             )
-            return types.SimpleNamespace(part_detail=[part], source_warehouse="WH")
+            return types.SimpleNamespace(part_detail=[part], set_warehouse="WH")
         return types.SimpleNamespace()
 
     frappe.get_doc = get_doc


### PR DESCRIPTION
## Summary
- Map Work Order `set_warehouse` into Workshop Material Issue and use it for item valuation
- Retrieve required parts using the Work Order's warehouse
- Align client logic with new warehouse field

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68963f0251e4832cb7f59ec46d82ca21