### PR TITLE
Only display Work Order PO button when purchase orders exist

### DIFF
--- a/car_workshop/car_workshop/doctype/work_order/work_order.js
+++ b/car_workshop/car_workshop/doctype/work_order/work_order.js
@@ -1,9 +1,21 @@
 frappe.ui.form.on('Work Order', {
     refresh: function(frm) {
-        // Add "Lihat Semua PO Terkait" button if there are related POs
-        frm.add_custom_button(__('Lihat Semua PO Terkait'), function() {
-            show_related_purchase_orders(frm);
-        }).addClass('btn-primary');
+        // Add "Lihat Semua PO Terkait" button only if there are related Purchase Orders
+        if (!frm.is_new()) {
+            frappe.db.get_list('Workshop Purchase Order', {
+                filters: {
+                    work_order: frm.doc.name,
+                    docstatus: ['!=', 2]
+                },
+                limit: 1
+            }).then(function(pos) {
+                if (pos && pos.length > 0) {
+                    frm.add_custom_button(__('Lihat Semua PO Terkait'), function() {
+                        show_related_purchase_orders(frm);
+                    }).addClass('btn-primary');
+                }
+            });
+        }
 
         // Add Material Issue button when submitted and not cancelled
         if (frm.doc.docstatus === 1 && frm.doc.status !== 'Cancelled') {


### PR DESCRIPTION
## Summary
- Only show "Lihat Semua PO Terkait" button on Work Order if a related Workshop Purchase Order exists

## Testing
- `pytest` *(fails: ImportError: cannot import name 'nowdate')*

------
https://chatgpt.com/codex/tasks/task_e_6896453126e4832ca0bda116f76fc967