### PR TITLE
Enhance billing workflow with cancellation handling and discount approval

### DIFF
--- a/car_workshop/car_workshop/workflow/work_order_billing_workflow/work_order_billing_workflow.json
+++ b/car_workshop/car_workshop/workflow/work_order_billing_workflow/work_order_billing_workflow.json
@@ -37,59 +37,102 @@
    "update_value": "Fully Paid",
    "idx": 4
   },
-  {
-   "state": "Completed",
-   "docstatus": 1,
-   "allow_edit": "Accountant",
-   "update_field": "status",
-   "update_value": "Completed",
-   "idx": 5
-  }
- ],
- "transitions": [
-  {
-   "state": "Draft",
-   "action": "Submit",
-   "next_state": "Pending Payment",
-   "allowed": "Workshop Manager",
-   "condition": "doc.discount_amount == 0",
-   "idx": 1
-  },
-  {
-   "state": "Draft",
-   "action": "Submit with Discount",
-   "next_state": "Pending Payment",
-   "allowed": "Accountant",
-   "condition": "doc.discount_amount > 0",
-   "idx": 2
-  },
-  {
-   "state": "Pending Payment",
-   "action": "Record Partial Payment",
-   "next_state": "Partially Paid",
-   "allowed": "Cashier",
-   "idx": 3
-  },
-  {
-   "state": "Pending Payment",
-   "action": "Record Full Payment",
-   "next_state": "Fully Paid",
-   "allowed": "Cashier",
-   "idx": 4
-  },
-  {
-   "state": "Partially Paid",
-   "action": "Record Remaining Payment",
-   "next_state": "Fully Paid",
-   "allowed": "Cashier",
-   "idx": 5
-  },
-  {
-   "state": "Fully Paid",
-   "action": "Complete",
-   "next_state": "Completed",
-   "allowed": "Accountant",
-   "idx": 6
-  }
- ]
+ {
+  "state": "Completed",
+  "docstatus": 1,
+  "allow_edit": "Accountant",
+  "update_field": "status",
+  "update_value": "Completed",
+  "idx": 5
+ },
+ {
+  "state": "Cancelled",
+  "docstatus": 2,
+  "allow_edit": "Accountant",
+  "update_field": "status",
+  "update_value": "Cancelled",
+  "idx": 6
+ }
+],
+"transitions": [
+ {
+  "state": "Draft",
+  "action": "Submit",
+  "next_state": "Pending Payment",
+  "allowed": "Workshop Manager",
+  "condition": "doc.discount_amount <= doc.get_discount_threshold()",
+  "idx": 1
+ },
+ {
+  "state": "Draft",
+  "action": "Submit for Approval",
+  "next_state": "Pending Payment",
+  "allowed": "Accountant",
+  "condition": "doc.discount_amount > doc.get_discount_threshold()",
+  "idx": 2
+ },
+ {
+  "state": "Pending Payment",
+  "action": "Record Partial Payment",
+  "next_state": "Partially Paid",
+  "allowed": "Cashier",
+  "idx": 3
+ },
+ {
+  "state": "Pending Payment",
+  "action": "Record Full Payment",
+  "next_state": "Fully Paid",
+  "allowed": "Cashier",
+  "idx": 4
+ },
+ {
+  "state": "Partially Paid",
+  "action": "Record Remaining Payment",
+  "next_state": "Fully Paid",
+  "allowed": "Cashier",
+  "idx": 5
+ },
+ {
+  "state": "Fully Paid",
+  "action": "Complete",
+  "next_state": "Completed",
+  "allowed": "Accountant",
+  "idx": 6
+ },
+ {
+  "state": "Pending Payment",
+  "action": "Cancel",
+  "next_state": "Cancelled",
+  "allowed": "Accountant",
+  "idx": 7
+ },
+ {
+  "state": "Partially Paid",
+  "action": "Cancel",
+  "next_state": "Cancelled",
+  "allowed": "Accountant",
+  "idx": 8
+ },
+ {
+  "state": "Fully Paid",
+  "action": "Cancel",
+  "next_state": "Cancelled",
+  "allowed": "Accountant",
+  "idx": 9
+ },
+ {
+  "state": "Completed",
+  "action": "Cancel",
+  "next_state": "Cancelled",
+  "allowed": "Accountant",
+  "idx": 10
+ },
+ {
+  "state": "Cancelled",
+  "action": "Amend",
+  "next_state": "Draft",
+  "allowed": "Accountant",
+  "idx": 11
+ }
+]
 }

--- a/tests/test_discount_approval.py
+++ b/tests/test_discount_approval.py
@@ -1,0 +1,76 @@
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+class Document:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+# Stubs
+frappe_utils_stub = types.SimpleNamespace(
+    flt=lambda x: float(x or 0),
+    cint=lambda x: int(x or 0),
+    getdate=lambda x: x,
+    nowdate=lambda: "2024-01-01",
+    add_days=lambda date, days: date,
+    get_datetime=lambda: "2024-01-01 00:00:00",
+)
+
+def _throw(msg):
+    raise Exception(msg)
+
+settings = {
+    "discount_approval_threshold": 50,
+    "discount_approver_roles": "Accountant",
+}
+
+frappe_stub = types.SimpleNamespace(
+    _=lambda msg: msg,
+    throw=_throw,
+    utils=frappe_utils_stub,
+    session=types.SimpleNamespace(user="test_user"),
+    db=types.SimpleNamespace(get_single_value=lambda doctype, field: settings.get(field)),
+    get_roles=lambda user=None: ["Workshop Manager"],
+    whitelist=lambda *a, **k: (lambda f: f),
+)
+
+frappe_stub.model = types.SimpleNamespace(document=types.SimpleNamespace(Document=Document))
+
+# Register modules
+sys.modules['frappe'] = frappe_stub
+sys.modules['frappe.model'] = frappe_stub.model
+sys.modules['frappe.model.document'] = frappe_stub.model.document
+sys.modules['frappe.utils'] = frappe_utils_stub
+sys.modules['erpnext.accounts.general_ledger'] = types.SimpleNamespace(make_gl_entries=lambda *a, **k: None)
+sys.modules['erpnext.accounts.utils'] = types.SimpleNamespace(get_account_currency=lambda *a, **k: None)
+sys.modules['erpnext.accounts.party'] = types.SimpleNamespace(get_party_account=lambda *a, **k: None)
+sys.modules['erpnext.controllers.accounts_controller'] = types.SimpleNamespace(AccountsController=Document)
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from car_workshop.car_workshop.doctype.work_order_billing.work_order_billing import WorkOrderBilling
+
+def test_discount_requires_approval_role_and_status():
+    wob = WorkOrderBilling(discount_amount=100, approval_status="Pending Approval")
+    with pytest.raises(Exception):
+        wob.validate_discount_approval()
+
+    frappe_stub.get_roles = lambda user=None: ["Accountant"]
+    with pytest.raises(Exception):
+        wob.validate_discount_approval()
+
+    wob.approval_status = "Approved"
+    wob.validate_discount_approval()
+
+
+def test_record_status_history_logs_user_and_timestamp():
+    messages = []
+    wob = WorkOrderBilling(status="Pending Payment")
+    wob.add_comment = lambda typ, msg: messages.append(msg)
+    wob.record_status_history()
+    assert "Pending Payment" in messages[0]
+    assert "test_user" in messages[0]
+    assert "2024-01-01 00:00:00" in messages[0]

--- a/tests/test_work_order_validation.py
+++ b/tests/test_work_order_validation.py
@@ -12,7 +12,11 @@ class Document:
     def get(self, name):
         return getattr(self, name, None)
 
-frappe_utils_stub = types.SimpleNamespace(flt=lambda x: float(x or 0))
+frappe_utils_stub = types.SimpleNamespace(
+    flt=lambda x: float(x or 0),
+    nowdate=lambda: "2024-01-01",
+    add_days=lambda d, n: d,
+)
 
 frappe_stub = types.SimpleNamespace(
     _=lambda msg: msg,


### PR DESCRIPTION
## Summary
- expand Work Order Billing workflow with cancellation/amendment transitions and discount threshold checks
- enforce role-based approval for high discounts and log state changes with user and timestamp
- add tests for discount approval and status history tracking

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896454eabc4832cb99c473373182f05